### PR TITLE
[Feat] Encyclopedia System [Refactor] WeaponData Setting for memories

### DIFF
--- a/Assets/04. JHT_Folder/Prefabs/ItemPrefab/AX.prefab
+++ b/Assets/04. JHT_Folder/Prefabs/ItemPrefab/AX.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5884566938386283838}
-  - component: {fileID: 5263971761092023153}
+  - component: {fileID: 5682252922067761371}
   m_Layer: 0
   m_Name: AX
   m_TagString: Untagged
@@ -32,7 +32,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &5263971761092023153
+--- !u!114 &5682252922067761371
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -41,14 +41,10 @@ MonoBehaviour:
   m_GameObject: {fileID: 5597114255676065821}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 82f2a4414b79c3b43bab90ed8cb3a776, type: 3}
+  m_Script: {fileID: 11500000, guid: e19c0ffb4714053429b6919305f50828, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  <itemSO>k__BackingField: {fileID: 11400000, guid: ef963a91a5eed324e82ba7609b548742, type: 2}
-  <itemNum>k__BackingField: 0
-  <itemIcon>k__BackingField: {fileID: 21300000, guid: a97ca0b99ece2d94aaaf59653feb45dd, type: 3}
-  <itemName>k__BackingField: AX
-  weapon: {fileID: 11400000, guid: ef963a91a5eed324e82ba7609b548742, type: 2}
-  itemLevel: 0
-  itemStar: 0
-  weaponPower: 0
+  itemSO: {fileID: 11400000, guid: ef963a91a5eed324e82ba7609b548742, type: 2}
+  itemName: 
+  itemNum: 0
+  itemIcon: {fileID: 0}

--- a/Assets/04. JHT_Folder/Prefabs/ItemPrefab/Bow.prefab
+++ b/Assets/04. JHT_Folder/Prefabs/ItemPrefab/Bow.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 9000147045566639261}
-  - component: {fileID: 444061218054403216}
+  - component: {fileID: 3113420557634856276}
   m_Layer: 0
   m_Name: Bow
   m_TagString: Untagged
@@ -32,7 +32,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &444061218054403216
+--- !u!114 &3113420557634856276
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -41,14 +41,10 @@ MonoBehaviour:
   m_GameObject: {fileID: 5672892275808093394}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 82f2a4414b79c3b43bab90ed8cb3a776, type: 3}
+  m_Script: {fileID: 11500000, guid: e19c0ffb4714053429b6919305f50828, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  <itemSO>k__BackingField: {fileID: 11400000, guid: f71aef64804b67b488d821796228187f, type: 2}
-  <itemNum>k__BackingField: 1
-  <itemIcon>k__BackingField: {fileID: 0}
-  <itemName>k__BackingField: 
-  weapon: {fileID: 0}
-  itemLevel: 0
-  itemStar: 0
-  weaponPower: 0
+  itemSO: {fileID: 11400000, guid: f71aef64804b67b488d821796228187f, type: 2}
+  itemName: 
+  itemNum: 1
+  itemIcon: {fileID: 0}

--- a/Assets/04. JHT_Folder/Prefabs/ItemPrefab/Sword.prefab
+++ b/Assets/04. JHT_Folder/Prefabs/ItemPrefab/Sword.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4272910647945016310}
-  - component: {fileID: 4550596665101304115}
+  - component: {fileID: 4942202424377928480}
   m_Layer: 0
   m_Name: Sword
   m_TagString: Untagged
@@ -32,7 +32,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &4550596665101304115
+--- !u!114 &4942202424377928480
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -41,14 +41,10 @@ MonoBehaviour:
   m_GameObject: {fileID: 2272620234067841818}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 82f2a4414b79c3b43bab90ed8cb3a776, type: 3}
+  m_Script: {fileID: 11500000, guid: e19c0ffb4714053429b6919305f50828, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  <itemSO>k__BackingField: {fileID: 11400000, guid: 9a42439cfd3e53d45b5058ac3e97e86e, type: 2}
-  <itemNum>k__BackingField: 2
-  <itemIcon>k__BackingField: {fileID: 0}
-  <itemName>k__BackingField: 
-  weapon: {fileID: 0}
-  itemLevel: 0
-  itemStar: 0
-  weaponPower: 0
+  itemSO: {fileID: 11400000, guid: 9a42439cfd3e53d45b5058ac3e97e86e, type: 2}
+  itemName: 
+  itemNum: 2
+  itemIcon: {fileID: 0}

--- a/Assets/04. JHT_Folder/Prefabs/UI/EncyclopediaPanelItem.prefab
+++ b/Assets/04. JHT_Folder/Prefabs/UI/EncyclopediaPanelItem.prefab
@@ -1,0 +1,169 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &162601284962604375
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6920420021811492580}
+  - component: {fileID: 519527296915233678}
+  - component: {fileID: 6724687520634231539}
+  - component: {fileID: 7359452532345875575}
+  m_Layer: 5
+  m_Name: EncyclopediaPanelItem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6920420021811492580
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 162601284962604375}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6962535712782196548}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &519527296915233678
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 162601284962604375}
+  m_CullTransparentMesh: 1
+--- !u!114 &6724687520634231539
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 162601284962604375}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3313b375511acb548a09290d34126af6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  encyclopediaImage: {fileID: 7359452532345875575}
+  frontImage: {fileID: 8742340142131251419}
+  itemName: 
+--- !u!114 &7359452532345875575
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 162601284962604375}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2494181189340629785
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6962535712782196548}
+  - component: {fileID: 3632554800894831823}
+  - component: {fileID: 8742340142131251419}
+  m_Layer: 5
+  m_Name: lockImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6962535712782196548
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2494181189340629785}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6920420021811492580}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3632554800894831823
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2494181189340629785}
+  m_CullTransparentMesh: 1
+--- !u!114 &8742340142131251419
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2494181189340629785}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.3962264, g: 0.3962264, b: 0.3962264, a: 0.77254903}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/Assets/04. JHT_Folder/Prefabs/UI/EncyclopediaPanelItem.prefab.meta
+++ b/Assets/04. JHT_Folder/Prefabs/UI/EncyclopediaPanelItem.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 642b60e3d5bc10f409cf89a2a4b5677d
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/04. JHT_Folder/Scenes/JHT_Test.unity
+++ b/Assets/04. JHT_Folder/Scenes/JHT_Test.unity
@@ -132,7 +132,7 @@ GameObject:
   - component: {fileID: 36434460}
   - component: {fileID: 36434459}
   m_Layer: 5
-  m_Name: InventoryCanvas
+  m_Name: Canvas
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -220,6 +220,7 @@ RectTransform:
   - {fileID: 849481238}
   - {fileID: 1235290237}
   - {fileID: 1205165460}
+  - {fileID: 870973195}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -227,6 +228,37 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &54304221
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 54304222}
+  m_Layer: 0
+  m_Name: ---------------------------------------
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &54304222
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 54304221}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 768.4543, y: 468.46564, z: -9.852089}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &133191419
 GameObject:
   m_ObjectHideFlags: 0
@@ -616,7 +648,9 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: -1
+  m_text: 'test
+
+'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -643,8 +677,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 70
-  m_fontSizeBase: 70
+  m_fontSize: 80.53
+  m_fontSizeBase: 80.53
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -730,9 +764,9 @@ RectTransform:
   m_Father: {fileID: 849008782}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: -17, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &426578427
 MonoBehaviour:
@@ -785,6 +819,96 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 426578425}
   m_CullTransparentMesh: 1
+--- !u!1 &428896681
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 428896682}
+  - component: {fileID: 428896685}
+  - component: {fileID: 428896684}
+  - component: {fileID: 428896683}
+  m_Layer: 5
+  m_Name: Viewport
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &428896682
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 428896681}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1164150027}
+  m_Father: {fileID: 888709080}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 1}
+--- !u!114 &428896683
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 428896681}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31a19414c41e5ae4aae2af33fee712f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ShowMaskGraphic: 0
+--- !u!114 &428896684
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 428896681}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10917, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &428896685
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 428896681}
+  m_CullTransparentMesh: 1
 --- !u!1 &507271929
 GameObject:
   m_ObjectHideFlags: 0
@@ -820,7 +944,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -0.00025194578}
+  m_AnchoredPosition: {x: 0, y: 0.00002861023}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &507271931
@@ -1012,6 +1136,37 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &549459244
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 549459245}
+  m_Layer: 0
+  m_Name: ---------------------------------------
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &549459245
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 549459244}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 768.4543, y: 468.46564, z: -9.852089}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &619394800
 GameObject:
   m_ObjectHideFlags: 0
@@ -1125,15 +1280,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: deed6ffae17cb634cabcfdb9f8c5f35c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  item1: {fileID: 5263971761092023153, guid: 140387058ec650b4d98674ecb465035e, type: 3}
-  item2: {fileID: 444061218054403216, guid: a3148c527648f7a46864a1916ff43ce1, type: 3}
-  item3: {fileID: 4550596665101304115, guid: cc59fde2926d2494ab00a606c0afc76d, type: 3}
+  item1: {fileID: 5682252922067761371, guid: 140387058ec650b4d98674ecb465035e, type: 3}
+  item2: {fileID: 3113420557634856276, guid: a3148c527648f7a46864a1916ff43ce1, type: 3}
+  item3: {fileID: 4942202424377928480, guid: cc59fde2926d2494ab00a606c0afc76d, type: 3}
   oneAddButton: {fileID: 1979522819}
   twoAddButton: {fileID: 1717027348}
   threeAddButton: {fileID: 1235290238}
   oneRemoveButton: {fileID: 745832729}
-  twoRemoveButton: {fileID: 849481239}
-  threeRemoveButton: {fileID: 1205165461}
+  twoRemoveButton: {fileID: 0}
+  threeRemoveButton: {fileID: 0}
 --- !u!4 &669009132
 Transform:
   m_ObjectHideFlags: 0
@@ -1411,6 +1566,132 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 682838300}
   m_CullTransparentMesh: 1
+--- !u!1 &689891434
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 689891435}
+  - component: {fileID: 689891438}
+  - component: {fileID: 689891437}
+  - component: {fileID: 689891436}
+  m_Layer: 5
+  m_Name: Scrollbar Vertical
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &689891435
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 689891434}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 956467429}
+  m_Father: {fileID: 888709080}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: -17}
+  m_Pivot: {x: 1, y: 1}
+--- !u!114 &689891436
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 689891434}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2a4db7a114972834c8e4117be1d82ba3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1362207694}
+  m_HandleRect: {fileID: 1362207693}
+  m_Direction: 2
+  m_Value: 0
+  m_Size: 1
+  m_NumberOfSteps: 0
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &689891437
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 689891434}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &689891438
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 689891434}
+  m_CullTransparentMesh: 1
 --- !u!1 &731936990
 GameObject:
   m_ObjectHideFlags: 0
@@ -1484,7 +1765,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 118, y: 587}
-  m_SizeDelta: {x: 100, y: 100}
+  m_SizeDelta: {x: 150, y: 150}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &745832729
 MonoBehaviour:
@@ -1735,6 +2016,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _dontDestroyOnLoad: 1
   weaponList: []
+  encyclopediaPanel: {fileID: 1786477724}
 --- !u!4 &761771645
 Transform:
   m_ObjectHideFlags: 0
@@ -1832,7 +2114,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 215119623}
   m_HandleRect: {fileID: 215119622}
   m_Direction: 2
-  m_Value: 1
+  m_Value: 0
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -2105,6 +2387,150 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 849481237}
   m_CullTransparentMesh: 1
+--- !u!1 &870973194
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 870973195}
+  m_Layer: 5
+  m_Name: Encyclopedia
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &870973195
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 870973194}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1786477723}
+  m_Father: {fileID: 36434462}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &888709079
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 888709080}
+  - component: {fileID: 888709083}
+  - component: {fileID: 888709082}
+  - component: {fileID: 888709081}
+  m_Layer: 5
+  m_Name: Scroll View
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &888709080
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 888709079}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 428896682}
+  - {fileID: 689891435}
+  m_Father: {fileID: 1786477723}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &888709081
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 888709079}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1aa08ab6e0800fa44ae55d278d1423e3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Content: {fileID: 1164150027}
+  m_Horizontal: 1
+  m_Vertical: 1
+  m_MovementType: 1
+  m_Elasticity: 0.1
+  m_Inertia: 1
+  m_DecelerationRate: 0.135
+  m_ScrollSensitivity: 1
+  m_Viewport: {fileID: 428896682}
+  m_HorizontalScrollbar: {fileID: 0}
+  m_VerticalScrollbar: {fileID: 689891436}
+  m_HorizontalScrollbarVisibility: 2
+  m_VerticalScrollbarVisibility: 2
+  m_HorizontalScrollbarSpacing: -3
+  m_VerticalScrollbarSpacing: -3
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &888709082
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 888709079}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &888709083
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 888709079}
+  m_CullTransparentMesh: 1
 --- !u!1 &932952205
 GameObject:
   m_ObjectHideFlags: 0
@@ -2141,7 +2567,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -55.467773}
+  m_AnchoredPosition: {x: 0, y: -55.46765}
   m_SizeDelta: {x: 0, y: -110.9361}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &932952208
@@ -2182,6 +2608,42 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 932952205}
   m_CullTransparentMesh: 1
+--- !u!1 &956467428
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 956467429}
+  m_Layer: 5
+  m_Name: Sliding Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &956467429
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 956467428}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1362207693}
+  m_Father: {fileID: 689891435}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: -20}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &986477062
 GameObject:
   m_ObjectHideFlags: 0
@@ -2218,6 +2680,81 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: -20, y: -20}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1164150026
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1164150027}
+  - component: {fileID: 1164150029}
+  - component: {fileID: 1164150028}
+  m_Layer: 5
+  m_Name: EncyclopediaParent
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1164150027
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1164150026}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 428896682}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0.0001373291}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 1}
+--- !u!114 &1164150028
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1164150026}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8a8695521f0d02e499659fee002a26c2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 72
+    m_Right: 0
+    m_Top: 128
+    m_Bottom: 0
+  m_ChildAlignment: 0
+  m_StartCorner: 0
+  m_StartAxis: 0
+  m_CellSize: {x: 200, y: 200}
+  m_Spacing: {x: 10, y: 10}
+  m_Constraint: 0
+  m_ConstraintCount: 2
+--- !u!114 &1164150029
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1164150026}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 0
+  m_VerticalFit: 2
 --- !u!1 &1205165459
 GameObject:
   m_ObjectHideFlags: 0
@@ -2762,8 +3299,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _dontDestroyOnLoad: 1
-  weaponList: []
-  relicsObject: []
   currentMode: 0
 --- !u!4 &1259159793
 Transform:
@@ -2953,6 +3488,81 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1362207692
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1362207693}
+  - component: {fileID: 1362207695}
+  - component: {fileID: 1362207694}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1362207693
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1362207692}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 956467429}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1362207694
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1362207692}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1362207695
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1362207692}
+  m_CullTransparentMesh: 1
 --- !u!1 &1418177598
 GameObject:
   m_ObjectHideFlags: 0
@@ -3074,6 +3684,37 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1418177598}
   m_CullTransparentMesh: 1
+--- !u!1 &1469606360
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1469606361}
+  m_Layer: 0
+  m_Name: ---------------------------------------
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1469606361
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1469606360}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 768.4543, y: 468.46564, z: -9.852089}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1547599741
 GameObject:
   m_ObjectHideFlags: 0
@@ -3573,7 +4214,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 260}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &1655555895
 MonoBehaviour:
@@ -4053,7 +4694,7 @@ RectTransform:
   m_Father: {fileID: 731936991}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -4094,6 +4735,97 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1780285609}
+  m_CullTransparentMesh: 1
+--- !u!1 &1786477722
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1786477723}
+  - component: {fileID: 1786477726}
+  - component: {fileID: 1786477725}
+  - component: {fileID: 1786477724}
+  m_Layer: 5
+  m_Name: EncyclopediaBack
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1786477723
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1786477722}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 888709080}
+  m_Father: {fileID: 870973195}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -279.2}
+  m_SizeDelta: {x: -59.999992, y: 1300}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1786477724
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1786477722}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1b8a2e2c51c8bf94599411b275bb86e4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  encyclopediaPanelItem: {fileID: 6724687520634231539, guid: 642b60e3d5bc10f409cf89a2a4b5677d, type: 3}
+  encyclopediaPanelItemParent: {fileID: 1164150027}
+--- !u!114 &1786477725
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1786477722}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1786477726
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1786477722}
   m_CullTransparentMesh: 1
 --- !u!1 &1801847005
 GameObject:
@@ -4250,11 +4982,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4740882110099497716, guid: 1bb7b287aceb36848a19b23b6bb132d6, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 200
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4740882110099497716, guid: 1bb7b287aceb36848a19b23b6bb132d6, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 200
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4740882110099497716, guid: 1bb7b287aceb36848a19b23b6bb132d6, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4286,11 +5018,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4740882110099497716, guid: 1bb7b287aceb36848a19b23b6bb132d6, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 35
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4740882110099497716, guid: 1bb7b287aceb36848a19b23b6bb132d6, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -60
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4740882110099497716, guid: 1bb7b287aceb36848a19b23b6bb132d6, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -4861,7 +5593,10 @@ SceneRoots:
   - {fileID: 519420032}
   - {fileID: 619394802}
   - {fileID: 2045413236}
+  - {fileID: 54304222}
   - {fileID: 36434462}
+  - {fileID: 1469606361}
   - {fileID: 1259159793}
-  - {fileID: 669009132}
   - {fileID: 761771645}
+  - {fileID: 549459245}
+  - {fileID: 669009132}

--- a/Assets/04. JHT_Folder/Scriptable/Ax.asset
+++ b/Assets/04. JHT_Folder/Scriptable/Ax.asset
@@ -15,15 +15,21 @@ MonoBehaviour:
   <itemName>k__BackingField: AX
   <itemType>k__BackingField: 0
   <icon>k__BackingField: {fileID: 21300000, guid: a97ca0b99ece2d94aaaf59653feb45dd, type: 3}
-  <backImage>k__BackingField: {fileID: 0}
+  <backImage>k__BackingField: {fileID: 4321518268088089880, guid: 66e3e59cfd03ace4fb9fa15ce343b014, type: 3}
   <desc>k__BackingField: 
   <isStrengthen>k__BackingField: 0
-  <weaponType>k__BackingField: 0
-  <characterWeaponType>k__BackingField: 0
+  <weaponType>k__BackingField: 2
+  <characterWeaponType>k__BackingField: 12
   <weaponClasses>k__BackingField:
   - star: 0
     levels: 01000000020000000300000004000000050000000600000006000000060000000600000006000000
   - star: 1
     levels: 0a0000000b0000000c0000000d0000000e0000000f000000
   <stars>k__BackingField: []
-  <projectile>k__BackingField: {fileID: 0}
+  <upPowerPercent>k__BackingField:
+  - 0.1
+  - 0.101
+  - 0.1
+  - 0.1
+  - 0.1
+  <maxLevelInCurStar>k__BackingField: 64000000c8000000050000000500000005000000

--- a/Assets/04. JHT_Folder/Scriptable/Bow.asset
+++ b/Assets/04. JHT_Folder/Scriptable/Bow.asset
@@ -14,12 +14,16 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   <itemName>k__BackingField: BOW
   <itemType>k__BackingField: 0
-  <icon>k__BackingField: {fileID: 0}
-  <backImage>k__BackingField: {fileID: 0}
+  <icon>k__BackingField: {fileID: 21300000, guid: b3905a73a6672d9449647aaf036e23fc, type: 3}
+  <backImage>k__BackingField: {fileID: -8251610326034200038, guid: ebe8de569e4ddf647ad61a3b01b0e07d, type: 3}
   <desc>k__BackingField: 
-  <attackDamage>k__BackingField: 10
   <isStrengthen>k__BackingField: 0
-  weaponType: 2
-  characterWeaponType: 4
-  levelParticle: []
-  <projectile>k__BackingField: {fileID: 0}
+  <weaponType>k__BackingField: 0
+  <characterWeaponType>k__BackingField: 0
+  <weaponClasses>k__BackingField: []
+  <stars>k__BackingField: []
+  <upPowerPercent>k__BackingField:
+  - 1
+  - 1
+  - 1
+  <maxLevelInCurStar>k__BackingField: 010000000100000001000000

--- a/Assets/04. JHT_Folder/Scriptable/Sword.asset
+++ b/Assets/04. JHT_Folder/Scriptable/Sword.asset
@@ -14,12 +14,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   <itemName>k__BackingField: SWORD
   <itemType>k__BackingField: 0
-  <icon>k__BackingField: {fileID: 0}
-  <backImage>k__BackingField: {fileID: 0}
+  <icon>k__BackingField: {fileID: 21300000, guid: 05c7216c78d4dd34ebe2bac9c1e274d7, type: 3}
+  <backImage>k__BackingField: {fileID: -8251610326034200038, guid: ebe8de569e4ddf647ad61a3b01b0e07d, type: 3}
   <desc>k__BackingField: 
-  <attackDamage>k__BackingField: 20
   <isStrengthen>k__BackingField: 0
-  weaponType: 2
-  characterWeaponType: 9
-  levelParticle: []
-  <projectile>k__BackingField: {fileID: 0}
+  <weaponType>k__BackingField: 0
+  <characterWeaponType>k__BackingField: 0
+  <weaponClasses>k__BackingField: []
+  <stars>k__BackingField: []
+  <upPowerPercent>k__BackingField: []
+  <maxLevelInCurStar>k__BackingField: 

--- a/Assets/04. JHT_Folder/Scripts/Demo/DemoAddWeapon.cs
+++ b/Assets/04. JHT_Folder/Scripts/Demo/DemoAddWeapon.cs
@@ -9,9 +9,9 @@ namespace JHT
     public class DemoAddWeapon : MonoBehaviour
     {
 
-        [SerializeField] private WeaponObject item1;
-        [SerializeField] private WeaponObject item2;
-        [SerializeField] private WeaponObject item3;
+        [SerializeField] private DataItem item1;
+        [SerializeField] private DataItem item2;
+        [SerializeField] private DataItem item3;
 
         public Button oneAddButton;
         public Button twoAddButton;
@@ -21,31 +21,32 @@ namespace JHT
         public Button twoRemoveButton;
         public Button threeRemoveButton;
 
-        private event Action<WeaponObject> OnClick;
+        private event Action<DataItem> OnClick;
+
         private void Start()
         {
             oneAddButton.onClick.AddListener(OnAdd1);
             twoAddButton.onClick.AddListener(OnAdd2);
             threeAddButton.onClick.AddListener(OnAdd3);
 
-            oneRemoveButton.onClick.AddListener(OnRemove1);
-            twoRemoveButton.onClick.AddListener(OnRemove2);
-            threeRemoveButton.onClick.AddListener(OnRemove3);
+           // twoRemoveButton.onClick.AddListener(OnRemove2);
+           // threeRemoveButton.onClick.AddListener(OnRemove3);
+
         }
 
-        public void AddWeapon(WeaponObject item)
+        public void AddWeapon(DataItem item)
         {
             InventoryManager.Instance.AddItem(item);
         }
 
-        public void RemoveWeapon(WeaponObject item)
+        public void RemoveWeapon(DataItem item)
         {
-            InventoryManager.Instance.RemoveItem(item);
+            //InventoryManager.Instance.RemoveItem(item);
         }
 
-        private void OnAdd1() => AddWeapon(item1);
-        private void OnAdd2() => AddWeapon(item2);
-        private void OnAdd3() => AddWeapon(item3);
+        private void OnAdd1() => AddWeapon(ItemDataManager.Instance.GetAllWeaponData()[item1.itemNum]);
+        private void OnAdd2() => AddWeapon(ItemDataManager.Instance.GetAllWeaponData()[item2.itemNum]);
+        private void OnAdd3() => AddWeapon(ItemDataManager.Instance.GetAllWeaponData()[item3.itemNum]);
         private void OnRemove1() => RemoveWeapon(item1);
         private void OnRemove2() => RemoveWeapon(item2);
         private void OnRemove3() => RemoveWeapon(item3);

--- a/Assets/04. JHT_Folder/Scripts/Encyclopedia.meta
+++ b/Assets/04. JHT_Folder/Scripts/Encyclopedia.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0adaea820c87a6040a3b5773576a8f00
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/04. JHT_Folder/Scripts/Encyclopedia/EncyclopediaPanel.cs
+++ b/Assets/04. JHT_Folder/Scripts/Encyclopedia/EncyclopediaPanel.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using Unity.VisualScripting;
+using UnityEngine;
+using UnityEngine.UI;
+
+
+namespace JHT
+{
+    public class EncyclopediaPanel : MonoBehaviour
+    {
+        public Dictionary<int, DataItem> weaponDic;
+        [SerializeField] private EncyclopediaPanelItem encyclopediaPanelItem;
+        [SerializeField] private Transform encyclopediaPanelItemParent;
+
+        public void Init()
+        {
+            weaponDic = new();
+
+            foreach (var k in ItemDataManager.Instance.GetAllWeaponData())
+                weaponDic[k.Key] = k.Value;
+
+            ShowAllWeapon();
+        }
+
+
+        private void ShowAllWeapon()
+        {
+            for (int i = 0; i < ItemDataManager.Instance.GetAllWeaponData().Count; i++)
+            {
+                EncyclopediaPanelItem obj = Instantiate(encyclopediaPanelItem);
+                obj.transform.SetParent(encyclopediaPanelItemParent);
+                obj.Init(ItemDataManager.Instance.GetAllWeaponData()[i]);
+            }
+        }
+    }
+}

--- a/Assets/04. JHT_Folder/Scripts/Encyclopedia/EncyclopediaPanel.cs.meta
+++ b/Assets/04. JHT_Folder/Scripts/Encyclopedia/EncyclopediaPanel.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1b8a2e2c51c8bf94599411b275bb86e4

--- a/Assets/04. JHT_Folder/Scripts/Encyclopedia/EncyclopediaPanelItem.cs
+++ b/Assets/04. JHT_Folder/Scripts/Encyclopedia/EncyclopediaPanelItem.cs
@@ -1,0 +1,33 @@
+using JHT;
+using Unity.VisualScripting;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class EncyclopediaPanelItem : MonoBehaviour
+{
+    public Image encyclopediaImage;
+    public Image frontImage;
+    public string itemName;
+
+    private DataItem sample;
+    public void Init(DataItem _weaponObject)
+    {
+        ItemWeaponSO weaponSO = (ItemWeaponSO)_weaponObject.itemSO;
+
+        sample = _weaponObject;
+        encyclopediaImage.sprite = _weaponObject.itemSO.icon;
+        frontImage.sprite = weaponSO.backImage;
+        itemName = _weaponObject.itemName;
+        InventoryManager.Instance.OnAddInventory += OpenItem;
+    }
+
+    private void OpenItem(ItemObject item)
+    {
+        if (item.itemNum == sample.itemNum)
+        {
+            if (frontImage != null)
+                Destroy(frontImage.gameObject);
+        }
+            
+    }
+}

--- a/Assets/04. JHT_Folder/Scripts/Encyclopedia/EncyclopediaPanelItem.cs.meta
+++ b/Assets/04. JHT_Folder/Scripts/Encyclopedia/EncyclopediaPanelItem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3313b375511acb548a09290d34126af6

--- a/Assets/04. JHT_Folder/Scripts/Inventory/InventoryManager.cs
+++ b/Assets/04. JHT_Folder/Scripts/Inventory/InventoryManager.cs
@@ -15,6 +15,7 @@ namespace JHT
         public Action<WeaponObject> OnUpCountItem;
 
         public InventoryMode currentMode;
+
         public void Start()
         {
             if(weaponList == null)
@@ -23,37 +24,38 @@ namespace JHT
             if(relicsObject == null)
                 relicsObject = new();
 
-            OnAddInventory += AddInventroyIndex;
+            OnAddInventory += AddInventroyWeapon;
             OnRemoveInventory += RemoveInventroyIndex;
         }
 
-        public void AddItem(ItemObject item)
+        public void AddItem(DataItem item)
         {
-            if (item as WeaponObject)
+            if (item.itemSO.itemType == ItemType.Weapon)
             {
-                WeaponObject obj = item as WeaponObject;
-                if (weaponList.Contains(obj))
+                WeaponObject existObj = weaponList.Find(x => x.itemNum == item.itemNum);
+                
+                if (existObj == null)
                 {
-                    OnUpCountItem?.Invoke(obj);
+                    WeaponObject obj = new WeaponObject(item);
+                    OnAddInventory?.Invoke(obj);
                 }
                 else
                 {
-                    OnAddInventory?.Invoke(obj);
-                    obj.Init();
+                    OnUpCountItem?.Invoke(existObj);
                 }
+                
             }
             else
             {
-                RelicsObject obj = item as RelicsObject;
+                //RelicsObject obj = item as RelicsObject;
             }
             
         }
 
         public void RemoveItem(ItemObject item)
         {
-            if (item as WeaponObject)
+            if (item is WeaponObject obj)
             {
-                WeaponObject obj = item as WeaponObject;
                 if (weaponList.Contains(obj))
                 {
                     OnRemoveInventory?.Invoke(item);
@@ -65,7 +67,7 @@ namespace JHT
             }
             else
             {
-                RelicsObject obj = item as RelicsObject;
+                //RelicsObject obj = item as RelicsObject;
             }
             
         }
@@ -75,28 +77,27 @@ namespace JHT
             weaponList.Clear();
         }
 
-        private void AddInventroyIndex(ItemObject item)
+        private void AddInventroyWeapon(ItemObject item)
         {
-            if (item as WeaponObject)
-            {;
-                weaponList.Add((WeaponObject)item);
+            if (item is WeaponObject obj)
+            {
+                weaponList.Add(obj);
             }
             else
             {
-                RelicsObject obj = item as RelicsObject;
+                //RelicsObject obj = item as RelicsObject;
             }
         }
 
         private void RemoveInventroyIndex(ItemObject item)
         {
-            if (item as WeaponObject)
+            if (item is WeaponObject obj)
             {
-                WeaponObject obj = item as WeaponObject;
                 weaponList.Remove(obj);
             }
             else
             {
-                RelicsObject obj = item as RelicsObject;
+                //RelicsObject obj = item as RelicsObject;
             }
         }
 

--- a/Assets/04. JHT_Folder/Scripts/Inventory/ItemPanelPrefab.cs
+++ b/Assets/04. JHT_Folder/Scripts/Inventory/ItemPanelPrefab.cs
@@ -28,12 +28,11 @@ namespace JHT
 
         public void Init(ItemObject item)
         {
-            if (item as WeaponObject)
+            if (item is WeaponObject)
             {
                 WeaponObject obj = (WeaponObject)item;
                 SetWeapon(obj);
                 obj.OnUpCount += UpCountAction;
-                obj.OnUpgrade += UpGradeAction;
             }
             else
             {
@@ -62,10 +61,6 @@ namespace JHT
             itemCountText.text = item.itemLevel.ToString();
         }
 
-        private void UpGradeAction(WeaponObject item)
-        {
-
-        }
 
     }
 }

--- a/Assets/04. JHT_Folder/Scripts/Item/DataItem.meta
+++ b/Assets/04. JHT_Folder/Scripts/Item/DataItem.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cb279293c66fa0849bb20f1318a8a9a2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/04. JHT_Folder/Scripts/Item/DataItem/DataItem.cs
+++ b/Assets/04. JHT_Folder/Scripts/Item/DataItem/DataItem.cs
@@ -1,0 +1,21 @@
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace JHT
+{
+    public class DataItem : MonoBehaviour
+    {
+        public ItemSO itemSO;
+        public string itemName;
+        public int itemNum;
+        public Image itemIcon;
+
+        public void Init()
+        {
+            itemIcon.sprite = itemSO.icon;
+            itemName = itemSO.itemName;
+        }
+
+    }
+}

--- a/Assets/04. JHT_Folder/Scripts/Item/DataItem/DataItem.cs.meta
+++ b/Assets/04. JHT_Folder/Scripts/Item/DataItem/DataItem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e19c0ffb4714053429b6919305f50828

--- a/Assets/04. JHT_Folder/Scripts/Item/ItemChild/RelicsObject.cs
+++ b/Assets/04. JHT_Folder/Scripts/Item/ItemChild/RelicsObject.cs
@@ -1,7 +1,10 @@
 using JHT;
 using UnityEngine;
 
-public class RelicsObject : ItemObject
+namespace JHT
 {
-   
+    public class RelicsObject : ItemObject
+    {
+
+    }
 }

--- a/Assets/04. JHT_Folder/Scripts/Item/ItemChild/WeaponObject.cs
+++ b/Assets/04. JHT_Folder/Scripts/Item/ItemChild/WeaponObject.cs
@@ -1,38 +1,33 @@
 using JHT;
+using NUnit.Framework.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using Unity.VisualScripting;
+using Unity.VisualScripting.Antlr3.Runtime;
 using UnityEngine;
 
 namespace JHT
 {
     public class WeaponObject : ItemObject
     {
-        public ItemWeaponSO weapon;
         public int itemLevel;
         public int itemStar;
         public float weaponPower;
+        private bool isUpgrade;
+        public bool IsUpgrade { get { return isUpgrade; } set { isUpgrade = value; OnUpgrade?.Invoke(isUpgrade); } }
+        public event Action<bool> OnUpgrade;
 
-        public Action<WeaponObject> OnUpgrade;
         public Action<WeaponObject> OnUpCount;
 
-        Dictionary<int, int[]> valueTable = null;
-
-        public override void Init()
+        public WeaponObject(DataItem sample)
         {
-            base.Init();
-            weapon = (ItemWeaponSO)itemSO;
-            itemIcon = weapon.icon;
-            OnUpCount += UpCountWeapon;
+            itemIcon = sample.itemSO.icon;
+            itemName = sample.itemSO.itemName;
+            itemNum = sample.itemNum;
+            itemSO = sample.itemSO;
+
             InventoryManager.Instance.OnUpCountItem += ItemLevelUp;
-
-            valueTable = new();
-
-            for (int i = 0; i < weapon.weaponClasses.Length; i++)
-            {
-                valueTable.Add(i, weapon.weaponClasses[i].levels);
-            }
         }
 
         public void ItemUpCount(ItemWeaponSO weapon)
@@ -44,52 +39,68 @@ namespace JHT
         public void ItemLevelUp(WeaponObject obj)
         {
             if (obj != this)
+            {
+                Debug.Log($"{obj.itemName} 없음 ");
                 return;
+            }
 
             itemLevel++;
             OnUpCount?.Invoke(obj);
+            UpCountWeapon();
+        }
 
-            //if (upCount >= weapon.MaxItemCount[itemLevel])
+        public WeaponObject OnAddItem(bool value)
+        {
+            return this;
+        }
+
+        // 방어코드 필요시 OnUpCount 구독 -> Weapon obj 넣어서
+        public void UpCountWeapon()
+        {
+            ItemWeaponSO weapon = (ItemWeaponSO)itemSO;
+            weaponPower += weapon.upPowerPercent[itemStar];
+            //while (itemLevel > weapon.maxLevelInCurStar[itemStar])
             //{
-            //    //지금은 자동형식 팝업통해 아이템 업글할건지 체크
-            //    Debug.Log("In");
-            //    OnUpgrade?.Invoke(obj);
-            //    upCount -= weapon.MaxItemCount[itemLevel];
-            //    itemStar++;
+            //    IsUpgrade = true;
             //}
         }
 
 
+        #region 우리애기
+
+        //Dictionary<int, int[]> valueTable = null;
+
+        //public void Init()
+        //{
+        //    valueTable = new();
+        //    
+        //    for (int i = 0; i < weapon.weaponClasses.Length; i++)
+        //    {
+        //        valueTable.Add(i, weapon.weaponClasses[i].levels);
+        //    }
+        //}
+
         // 레벨업시 아이템에 효과 줄 메서드
-        public void UpgradeWeapon(WeaponObject item)
-        {
-            if (item != this)
-                return;
+        //public void UpgradeWeapon(WeaponObject item)
+        //{
+        //    if (item != this)
+        //        return;
+        //
+        //    weaponPower = GetPower(item.itemStar, item.itemLevel);
+        //}
 
-            weaponPower = GetPower(item.itemStar, item.itemLevel);
-        }
-
-        public void UpCountWeapon(WeaponObject item)
-        {
-            if (item != this)
-                return;
-
-            weaponPower = GetPower(item.itemStar, item.itemLevel);
-            Debug.Log($"WeaponPower : {GetPower(item.itemStar, item.itemLevel)}");
-        }
-
-        public float GetPower(int _star, int _upCount)
-        {
-            if (valueTable.TryGetValue(_star, out int[] values))
-            {
-                //Debug.Log($"딕셔너리 갯수: valueTable : {valueTable.Count} ----- values : {values.Length}");
-                return values[_upCount];
-            }
-            else
-            {
-                Debug.LogError($"업카운트 {_upCount} 가 {values.Length} 범위를 벗어남");
-                return 0f;
-            }
-        }
+        //public float GetPower(int _star, int _upCount)
+        //{
+        //    if (valueTable.TryGetValue(_star, out int[] values))
+        //    {
+        //        return values[_upCount];
+        //    }
+        //    else
+        //    {
+        //        Debug.LogError($"업카운트 {_upCount} 가 {values.Length} 범위를 벗어남");
+        //        return 0f;
+        //    }
+        //}
+        #endregion
     }
 }

--- a/Assets/04. JHT_Folder/Scripts/Item/ItemDataManager.cs
+++ b/Assets/04. JHT_Folder/Scripts/Item/ItemDataManager.cs
@@ -12,11 +12,10 @@ namespace JHT
 {
     public class ItemDataManager : Singleton<ItemDataManager>
     {
-        private const string WEAPON_PATH = "JHT_ItemWeapon";
         private const string WEAPON_LABEL = "ItemWeapon";
-        public List<WeaponObject> weaponList;
-        public Dictionary<int, WeaponObject> weaponDataDic;
-
+        public List<DataItem> weaponList;
+        public Dictionary<int, DataItem> weaponDataDic;
+        public EncyclopediaPanel encyclopediaPanel;
         //public List<RelicsObject> relicsList;
         //public Dictionary<int, List<RelicsObject>> relicsDataDic;
 
@@ -27,36 +26,33 @@ namespace JHT
         {
             base.Awake();
 
-            StartCoroutine(WeaponDataSetting());
+            //StartCoroutine(WeaponDataSetting());
         }
 
-        private IEnumerator WeaponDataSetting()
+        private IEnumerator Start()
         {
+            yield return null;
+
             weaponList = new();
             weaponDataDic = new();
 
             weaponHandle = Addressables.LoadAssetsAsync<GameObject>(WEAPON_LABEL);
 
             yield return weaponHandle;
-            Debug.Log($"aaaaaaaaaaa : {weaponHandle}");
 
-            for (int i = 0; i < weaponHandle.Result.Count; i++)
-            {
-                Debug.Log($"bbbbbbbbb : {weaponHandle.Result[i]}");
-            }
-            weaponHandle.Completed += (w) => LoadWeaponList(weaponHandle);
+            LoadWeaponList(weaponHandle);
 
         }
         
         private void LoadWeaponList(AsyncOperationHandle<IList<GameObject>> objs)
         {
-            List<WeaponObject> list = new();
+            List<DataItem> list = new();
             foreach(var w in objs.Result)
             {
-                list.Add(w.GetComponent<WeaponObject>());
+                list.Add(w.GetComponent<DataItem>());
             }
 
-            List<WeaponObject> sortList = list.OrderBy(w => w.itemName).ToList();
+            List<DataItem> sortList = list.OrderBy(w => w.itemName).ToList();
 
             for (int i =0; i < sortList.Count; i ++)
             {
@@ -67,7 +63,7 @@ namespace JHT
         }
 
 
-        private void LoadWeaponFinish(List<WeaponObject> list)
+        private void LoadWeaponFinish(List<DataItem> list)
         {
             weaponDataDic.Clear();
 
@@ -77,17 +73,23 @@ namespace JHT
                     weaponDataDic.Add(list[i].itemNum, list[i]);
             }
 
+            if (weaponHandle.Status == AsyncOperationStatus.Succeeded)
+            {
+                //if (encyclopediaPanel == null)
+                //    encyclopediaPanel = FindObjectOfType<EncyclopediaPanel>();
+                StartCoroutine(EndInit());
+            }
         }
 
-        private void Update()
+        private IEnumerator EndInit()
         {
-            //if (Input.GetKeyDown(KeyCode.Space))
-            //{
-            //    foreach (var w in weaponDataDic)
-            //    {
-            //        Debug.Log($"weaponDic : {w.Value.itemName}");
-            //    }
-            //}
+            yield return new WaitForEndOfFrame();
+            encyclopediaPanel.Init();
+        }
+
+        public Dictionary<int, DataItem> GetAllWeaponData()
+        {
+            return weaponDataDic;
         }
     }
 }

--- a/Assets/04. JHT_Folder/Scripts/Item/ItemObject.cs
+++ b/Assets/04. JHT_Folder/Scripts/Item/ItemObject.cs
@@ -7,14 +7,15 @@ using UnityEngine.UI;
 namespace JHT
 {
     //구조 바꿔야함 상속으로 전체 아이템 담을거임
-    public class ItemObject : MonoBehaviour
+    
+    public class ItemObject
     {
-        [field: SerializeField] public ItemSO itemSO { get; private set; }
-        [field: SerializeField] public int itemNum { get; private set; }
+        public ItemSO itemSO { get; set; }
+        public int itemNum { get; set; }
 
-        [field: SerializeField] public Sprite itemIcon { get; set; }
+        public Sprite itemIcon { get; set; }
 
-        [field: SerializeField] public string itemName { get; set; }
+        public string itemName { get; set; }
 
         public virtual void Init()
         {

--- a/Assets/04. JHT_Folder/Scripts/Item/ItemSO.cs
+++ b/Assets/04. JHT_Folder/Scripts/Item/ItemSO.cs
@@ -8,7 +8,7 @@ namespace JHT
         [field: SerializeField] public string itemName { get; private set; }
         [field: SerializeField] public ItemType itemType { get; private set; }
         [field: SerializeField] public Sprite icon { get; private set; } = null;
-        [field: SerializeField] public Image backImage { get; private set; }
+        [field: SerializeField] public Sprite backImage { get; private set; }
         [field: SerializeField] public string desc { get; private set; }
         [field: SerializeField] public bool isStrengthen { get; private set; }
 

--- a/Assets/04. JHT_Folder/Scripts/Item/ItemWeaponSO.cs
+++ b/Assets/04. JHT_Folder/Scripts/Item/ItemWeaponSO.cs
@@ -13,6 +13,7 @@ namespace JHT
         public int[] levels;
     }
 
+    [CreateAssetMenu(menuName = "Scriptable_Weapon", fileName = "Scriptable_Weapon/Weapon")]
     public class ItemWeaponSO : ItemSO
     {
         [field: SerializeField] public WeaponType weaponType { get; private set; }
@@ -20,6 +21,9 @@ namespace JHT
 
         [field: SerializeField] public WeaponClass[] weaponClasses { get; private set; } = null;
         [field: SerializeField] public Image[] stars { get; private set; }
+        [field: SerializeField] public float[] upPowerPercent { get; private set; }
+        [field: SerializeField] public int[] maxLevelInCurStar { get; private set; }
+
 
         public override void UseItem(ItemSO item)
         {

--- a/Assets/04. JHT_Folder/Scripts/Item/SO/WeaponSO.cs
+++ b/Assets/04. JHT_Folder/Scripts/Item/SO/WeaponSO.cs
@@ -2,9 +2,9 @@ using UnityEngine;
 
 namespace JHT
 {
-    [CreateAssetMenu(menuName = "Scriptable_Weapon", fileName = "Scriptable_Weapon/Weapon")]
+    
     public class WeaponSO : ItemWeaponSO
     {
-        [field: SerializeField] public GameObject projectile { get; private set; } = null;
+        
     }
 }

--- a/Assets/AddressableAssetsData/AssetGroups/JHT.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/JHT.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   m_GUID: cbffc278f08107848a6a2a2d20a6be00
   m_SerializeEntries:
   - m_GUID: 21ee08eeeb7289c4daa2d2a752d1a27a
-    m_Address: JHT_ItemWeapon
+    m_Address: Assets/04. JHT_Folder/Prefabs/ItemPrefab
     m_ReadOnly: 0
     m_SerializedLabels:
     - ItemWeapon


### PR DESCRIPTION
[Feat]도감시스템
[Refactor] 메모리를 위해 Weapon데이터에 관련된 Manager와 WeaponObject수정

## 📄 작업 내용 요약
도감시스템 제작 및 메모리 관리를 위한 refactor 진행

## 📎 상세 작업 내용
addressable로 모든 아이템 로딩 후 도감에 필요한 부분의 데이터만 가져와서 저장하도록 설정,
WeaponObject를 생성자로 만들어서 오브젝트가 필요할 때 WeaponObject의 데이터가 필요한 곳에서만 생성될 수 있도록 설정