### PR TITLE
[fix] Quest 버그 수정

### DIFF
--- a/Assets/02. Scripts/Manager/DatabaseManager.cs
+++ b/Assets/02. Scripts/Manager/DatabaseManager.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using _05._CSJ_Folder.Scripts.Quest.Data;
 using Firebase.Auth;
@@ -781,6 +783,11 @@ public class DatabaseManager : Singleton<DatabaseManager>
             }
 
         }
+
+        if (data?.Tutorial is not null)
+        {
+            payload[$"{root}/Tutorial/Cleared"] = data.Tutorial.ClearedTutorialQuestIds;
+        }
         
         // 해당 payload들을 딕셔너리로 저장
         await SaveFieldsAsync(payload);
@@ -800,7 +807,8 @@ public class DatabaseManager : Singleton<DatabaseManager>
         var result = new QuestData
         {
             General = new GeneralQuestData(),
-            Temporary = new Dictionary<string, TemporaryQuestData>()
+            Temporary = new Dictionary<string, TemporaryQuestData>(),
+            Tutorial = new TutorialQuestData(),
         };
 
         // 반환 받은 데이터에서 General의 자식들을 받아옴
@@ -836,6 +844,18 @@ public class DatabaseManager : Singleton<DatabaseManager>
                 result.Temporary[questId] = t;
             }
         }
+        
+        var TutoNode = snapshot.Child("Tutorial");
+        if (TutoNode.Exists)
+        {
+            var clearedNode = TutoNode.Child("Cleared");
+            result.Tutorial.ClearedTutorialQuestIds = ReadStringListFromSnapshot(clearedNode);
+        }
+        else
+        {
+            result.Tutorial.ClearedTutorialQuestIds = new List<string>();
+        }
+
 
         return result;
     }
@@ -850,6 +870,49 @@ public class DatabaseManager : Singleton<DatabaseManager>
     {
         if (value == null) return defaultValue;
         return Convert.ToInt32(value);
+    }
+
+    private static List<string> ReadStringListFromSnapshot(DataSnapshot snapshot)
+    {
+        var result = new List<string>();
+        if (snapshot is null || !snapshot.Exists) return result;
+
+        if (snapshot.Value is IList list)
+        {
+            foreach (var item in list)
+            {
+                var s = item as string ?? item?.ToString();
+                if (!string.IsNullOrEmpty(s))
+                    result.Add(s);
+            }
+
+            return result;
+        }
+
+        var indexs = new List<(int idx, string val)>();
+        foreach (var child in snapshot.Children)
+        {
+            if (int.TryParse(child.Key, out var idx))
+            {
+                var s = child.Value as string ?? child.Value?.ToString();
+                if (!string.IsNullOrEmpty(s))
+                    indexs.Add((idx, s));
+            }
+        }
+        if (indexs.Count > 0)
+        {
+            indexs.Sort((a, b) => a.idx.CompareTo(b.idx));
+            result.AddRange(indexs.Select(p => p.val));
+            return result;
+        }
+
+        foreach (var child in snapshot.Children)
+        {
+            var s = child.Value as string ?? child.Value?.ToString();
+            if (!string.IsNullOrEmpty(s))
+                result.Add(s);
+        }
+        return result;
     }
     #endregion
     

--- a/Assets/05. CSJ_Folder/Scenes/QuestTestScene.unity
+++ b/Assets/05. CSJ_Folder/Scenes/QuestTestScene.unity
@@ -1380,7 +1380,7 @@ GameObject:
   - component: {fileID: 1763425638}
   - component: {fileID: 1763425637}
   m_Layer: 5
-  m_Name: Button
+  m_Name: QuestOpenButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1933,6 +1933,25 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!224 &701232105855762175
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4395015414929039937}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8122654153967336412}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 400, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &703943922268400342
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -2298,6 +2317,62 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3972577471053695637}
   m_CullTransparentMesh: 1
+--- !u!114 &1099340706709031421
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6799135996817808083}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 5817389473097964225}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 0}
+        m_TargetAssemblyTypeName: 
+        m_MethodName: 
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: 
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 1
 --- !u!114 &1117150335696335466
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2939,6 +3014,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 1703541223}
     - target: {fileID: 1806168120978448581, guid: ab78a24db6a8d144fb5ed0721e98c8f6, type: 3}
+      propertyPath: _InitButton
+      value: 
+      objectReference: {fileID: 1099340706709031421}
+    - target: {fileID: 1806168120978448581, guid: ab78a24db6a8d144fb5ed0721e98c8f6, type: 3}
       propertyPath: _CheatButton
       value: 
       objectReference: {fileID: 90373097}
@@ -3074,6 +3153,14 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5781151472538239582}
+  m_CullTransparentMesh: 1
+--- !u!222 &2675617284658604679
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4395015414929039937}
   m_CullTransparentMesh: 1
 --- !u!224 &2811450832380882735
 RectTransform:
@@ -3741,6 +3828,105 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!222 &4266950208801498586
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6799135996817808083}
+  m_CullTransparentMesh: 1
+--- !u!114 &4273275726062005639
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4395015414929039937}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Init
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: eac16899becdbf64cb9c8b68feb6f2fb, type: 2}
+  m_sharedMaterial: {fileID: 3621194056240108115, guid: eac16899becdbf64cb9c8b68feb6f2fb, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 56
+  m_fontSizeBase: 56
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &4273904807273323289
 GameObject:
   m_ObjectHideFlags: 0
@@ -3838,6 +4024,24 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4395015414929039937
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 701232105855762175}
+  - component: {fileID: 2675617284658604679}
+  - component: {fileID: 4273275726062005639}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!224 &4500403104475790400
 RectTransform:
   m_ObjectHideFlags: 0
@@ -3991,6 +4195,7 @@ RectTransform:
   - {fileID: 1703541220}
   - {fileID: 1579063727}
   - {fileID: 2115613849}
+  - {fileID: 8122654153967336412}
   - {fileID: 1763425636}
   - {fileID: 3157739108309863858}
   m_Father: {fileID: 0}
@@ -4342,6 +4547,36 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &5817389473097964225
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6799135996817808083}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &6003901435156289152
 GameObject:
   m_ObjectHideFlags: 0
@@ -4615,6 +4850,25 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6799135996817808083
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8122654153967336412}
+  - component: {fileID: 4266950208801498586}
+  - component: {fileID: 5817389473097964225}
+  - component: {fileID: 1099340706709031421}
+  m_Layer: 5
+  m_Name: InitButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!222 &6822220616450149679
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -5005,6 +5259,26 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!224 &8122654153967336412
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6799135996817808083}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 701232105855762175}
+  m_Father: {fileID: 4756870508083661799}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 566, y: 306}
+  m_SizeDelta: {x: 300, y: 300}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &8132887522768522320
 GameObject:
   m_ObjectHideFlags: 0
@@ -5091,8 +5365,6 @@ MonoBehaviour:
   _dailyPanel: {fileID: 2933611499961614681}
   _weeklyButton: {fileID: 5122609171016225336}
   _weeklyPanel: {fileID: 647081845064692310}
-  TypeText: {fileID: 966855626159627733}
-  isStarted: 0
 --- !u!1 &8293827521930632809
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/05. CSJ_Folder/Scripts/Quest/Data/QuestData.cs
+++ b/Assets/05. CSJ_Folder/Scripts/Quest/Data/QuestData.cs
@@ -8,5 +8,6 @@ namespace _05._CSJ_Folder.Scripts.Quest.Data
     {
         public GeneralQuestData General;
         public Dictionary<string,TemporaryQuestData> Temporary;
+        public TutorialQuestData Tutorial;
     }
 }

--- a/Assets/05. CSJ_Folder/Scripts/Quest/Data/TutorialQuestData.cs
+++ b/Assets/05. CSJ_Folder/Scripts/Quest/Data/TutorialQuestData.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace _05._CSJ_Folder.Scripts.Quest.Data
+{
+    public class TutorialQuestData
+    {
+        public List<string> ClearedTutorialQuestIds;
+    }
+}

--- a/Assets/05. CSJ_Folder/Scripts/Quest/Data/TutorialQuestData.cs.meta
+++ b/Assets/05. CSJ_Folder/Scripts/Quest/Data/TutorialQuestData.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2886dd4ed59f44eea6a7cdba73d9013b
+timeCreated: 1757627628

--- a/Assets/05. CSJ_Folder/Scripts/Quest/GeneralQuestInstance.cs
+++ b/Assets/05. CSJ_Folder/Scripts/Quest/GeneralQuestInstance.cs
@@ -6,24 +6,31 @@ namespace _05._CSJ_Folder.Scripts.Quest
     {
         public readonly string GeneralQuestId;
         
-        private GeneralQuestDefinitionSO _def;
+        public GeneralQuestDefinitionSO Def { get; }
 
         public GeneralQuestInstance(string questId, GeneralQuestDefinitionSO def)
         {
             GeneralQuestId = questId;
-            _def = def;
+            Def = def;
         }
         
 
         public override bool IsCompleted()
         {
-            int goalRequiredCount = _def.Goal.RequireCount;
+            int goalRequiredCount = Def.Goal.RequireCount;
             // 목표보다 현재 Count수가 작다면
             if (goalRequiredCount > CurrentGoalCount)
             {
                 return false;
             }
             return true;
+        }
+
+        public override bool IsOnce()
+        {
+            if (Def.RepeatType == RepeatType_Enum.Once)
+                return true;
+            return false;
         }
     }
 }

--- a/Assets/05. CSJ_Folder/Scripts/Quest/QuestInstance.cs
+++ b/Assets/05. CSJ_Folder/Scripts/Quest/QuestInstance.cs
@@ -38,6 +38,8 @@ namespace _05._CSJ_Folder.Scripts.Quest
         /// </summary>
         /// <returns></returns>
         public abstract bool IsCompleted();
+        
+        public abstract bool IsOnce();
 
         public void GoalCountAdjust(int count)
         {

--- a/Assets/05. CSJ_Folder/Scripts/Quest/QuestManager.cs
+++ b/Assets/05. CSJ_Folder/Scripts/Quest/QuestManager.cs
@@ -38,7 +38,7 @@ namespace _05._CSJ_Folder.Scripts.Quest
         private Queue<TemporaryInstance> _dailyQuests;
         private Queue<TemporaryInstance> _weeklyQuests;
         private Queue<TemporaryInstance> _temporaryQuests;
-        
+
         // event Dictionary
         // 퀘스트 정의 딕셔너리 < questId, definitionSO>
         private Dictionary<string, GeneralQuestDefinitionSO> _generalDefs;
@@ -48,6 +48,11 @@ namespace _05._CSJ_Folder.Scripts.Quest
         private Dictionary<string, GeneralQuestInstance>  _generalInstances;
 
         private Dictionary<string, TemporaryInstance> _temporaryInstances;
+        
+        private List<string> _clearedTutorialQuestIds;
+        
+        private GeneralQuestInstance _stageClearInstance;
+        private GeneralQuestInstance _completedInstance;
         
         // 클리어한 퀘스트 개수, 완료 버튼을 누를때 +1
         private int ClearedQuestCount;
@@ -108,6 +113,7 @@ namespace _05._CSJ_Folder.Scripts.Quest
             _generalQuests = new Queue<GeneralQuestDefinitionSO>();
             _dailyQuests = new();
             _weeklyQuests = new();
+            _clearedTutorialQuestIds = new List<string>();
             
             // 현재 존재하는 퀘스트 목록들을 _defs 딕셔너리에 추가
             BuildCatalog();
@@ -161,6 +167,7 @@ namespace _05._CSJ_Folder.Scripts.Quest
                 // 테스트용 코드 구독해제
                 // TODO: 정식 출시시 삭제
                 _questUI.OnForceClear -= ForceQuestComplete;
+                _questUI.OnForceInit -= ForceQuestReset;
 
                 OnQuestCompleted -= _questUI.UpdateQuest;
                 OnQuestUpdated -= _questUI.UpdateQuest;
@@ -215,6 +222,7 @@ namespace _05._CSJ_Folder.Scripts.Quest
             yield return CheckTemporaryQuestsReset(dailyCheck, weeklyCheck).AsIEnumerator();
 
             ScheduleNextResetTick();
+            
         }
 
         #endregion
@@ -275,6 +283,7 @@ namespace _05._CSJ_Folder.Scripts.Quest
             
             // 삭제
             _questUI.OnForceClear -= ForceQuestComplete;
+            _questUI.OnForceInit -= ForceQuestReset;
             
             _questUI = null;
             QuestUI = null;
@@ -304,11 +313,11 @@ namespace _05._CSJ_Folder.Scripts.Quest
             // 튜토리얼 삽입(수정)
             InsertTutorials();
             
-            // 이후 현재 퀘스트 진행 스테이지를 +1 
-            CurrentQuestStage++;
-            
             // 반복 퀘스트 삽입
             InsertRoutineQuest();
+            
+            // 이후 현재 퀘스트 진행 스테이지를 +1 
+            CurrentQuestStage++;
         }
 
         //TODO : 추후 어떻게 넣을지 생각하고 수정할 예정입니다.
@@ -350,8 +359,9 @@ namespace _05._CSJ_Folder.Scripts.Quest
                     stageClearMission = $"스테이지 {CurrentQuestStage}를 클리어 하세요"
                 };
                 // 해당 미션과 인스턴스 연결
-                _instances.Add(_stageClearTemplate.questId, inst);
-                _generalInstances.Add(_stageClearTemplate.questId, inst);
+                _instances.TryAdd(_stageClearTemplate.questId, inst);
+                _generalInstances.TryAdd(_stageClearTemplate.questId, inst);
+                _stageClearInstance = inst;
             }
             // 인스턴스를 찾았다면
             else
@@ -480,13 +490,18 @@ namespace _05._CSJ_Folder.Scripts.Quest
             // 일반 퀘스트 큐가 비어있다면 일반 퀘스트 큐를 채우는 것을 진행
             if (_generalQuests.Count == 0)
             {
-                // 일반 퀘스트 삽입
-                GeneralQuestEnqueue();
-                // 만약 그래도 큐가 비어있다면 큐 채우기에 문제가 발생한 것이므로 에러 발생
-                if (_generalQuests.Count == 0)
+                InsertQuest();
+            }
+
+            if (_clearedTutorialQuestIds.Contains(_generalQuests.Peek().questId))
+            {
+                while (_clearedTutorialQuestIds.Contains(_generalQuests.Peek().questId))
                 {
-                    Debug.LogError($"현재 일반 퀘스트 큐에 퀘스트를 삽입할 수 없습니다. 퀘스트 목록을 확인해주세요");
-                    return;
+                    _generalQuests.Dequeue();
+                    if (_generalQuests.Count == 0)
+                    {
+                        InsertQuest();
+                    }
                 }
             }
             
@@ -494,6 +509,15 @@ namespace _05._CSJ_Folder.Scripts.Quest
             var next = _generalQuests.Dequeue();
             // 인자로 해당 퀘스트를 넘김
             EnsureActive(next);
+        }
+
+        private void InsertQuest()
+        {
+            // 일반 퀘스트 삽입
+            GeneralQuestEnqueue();
+            // 만약 그래도 큐가 비어있다면 큐 채우기에 문제가 발생한 것이므로 에러 발생
+            if (_generalQuests.Count != 0) return;
+            Debug.LogError($"현재 일반 퀘스트 큐에 퀘스트를 삽입할 수 없습니다. 퀘스트 목록을 확인해주세요");
         }
         
         /// <summary>
@@ -504,11 +528,12 @@ namespace _05._CSJ_Folder.Scripts.Quest
             // 현재 인스턴스가 활성화 중인 경우 탈출 
             if (GetActiveGeneralInstance() != null) return false;
 
+            GeneralQuestInstance g;
             // 인스턴스에서 questId로 탐색 실패시 (=_instances에 def가 없는 경우)
             if (!_instances.TryGetValue(def.questId, out var inst))
             {
                 // 새로운 인스턴스를 생성합니다.
-                var g = new GeneralQuestInstance(def.questId, def)
+                g = new GeneralQuestInstance(def.questId, def)
                 {
                     QuestState = QuestState_Enum.Active,
                     GeneralQuestCount = computeQuestNumber(),
@@ -518,11 +543,17 @@ namespace _05._CSJ_Folder.Scripts.Quest
                 _generalInstances.Add(def.questId, g);
 
                 _activeGeneralId = g.QuestId;
+                if (IsStageCleared(g.Def))
+                {
+                    g.QuestState = QuestState_Enum.Completed;
+                    _completedInstance = g;
+                }
             }
             // 탐색에 성공했다면
             else
             {
-                if (inst is not GeneralQuestInstance g) return false;
+                if (inst is not GeneralQuestInstance) return false;
+                g = inst as GeneralQuestInstance;
                 // 인스턴스를 활성화 상태로 변경
                 g.QuestState = QuestState_Enum.Active;
                 // 인스턴스의 카운트를 초기화
@@ -532,10 +563,30 @@ namespace _05._CSJ_Folder.Scripts.Quest
                     _generalInstances.Add(def.questId,g);
 
                 _activeGeneralId = g.QuestId;
+                if (IsStageCleared(g.Def))
+                {
+                    g.QuestState = QuestState_Enum.Completed;
+                    _completedInstance = g;
+                }
             }
-            
-            RefreshActiveQuestUI();
+
+            RefreshActiveQuestUI(def, g);
             return true;
+        }
+        
+        private bool IsStageCleared(GeneralQuestDefinitionSO def)
+        {
+            if (def is null) return false;
+            
+
+            if (def.GeneralType == GeneralType_Enum.StageClear &&
+                CurrentClearedStage >= _stageClearInstance.needToClearStage)
+            {
+                _stageClearInstance.GoalCountAdjust(CurrentClearedStage);
+                return true;
+            }
+
+            return false;
         }
         
         #endregion
@@ -635,6 +686,8 @@ namespace _05._CSJ_Folder.Scripts.Quest
         {
             if(!IsInstanceComplete(inst)) return;
 
+            _completedInstance = inst;
+
             // 퀘스트 상태를 완료상태로 전환
             inst.QuestState = QuestState_Enum.Completed;
                         
@@ -715,14 +768,15 @@ namespace _05._CSJ_Folder.Scripts.Quest
         private void ReceiveReward(QuestDefinitionSO def, QuestInstance inst)
         {
             if (def is null || inst is null) return;
-
             if (inst.QuestState == QuestState_Enum.Received) return;
-
             if (!inst.IsCompleted()) return;
-            
             // def의 보상에서 획득을 호출합니다.
             def.Reward.AddReward(this);
-            
+
+            if (inst.IsOnce())
+            {
+                _clearedTutorialQuestIds.Add(inst.QuestId);
+            }
             if (def.isGeneral)
                 // 일반 퀘스트의 보상처리를 마무리합니다.
                 OnGeneralCompleted();
@@ -738,6 +792,9 @@ namespace _05._CSJ_Folder.Scripts.Quest
         {
             return ClearedQuestCount + 1;
         }
+
+    
+        
         #endregion
 
         #region UI
@@ -747,12 +804,15 @@ namespace _05._CSJ_Folder.Scripts.Quest
         /// </summary>
         private void ActiveQuestUI()
         {
+            Debug.Log("ActiveQuestUI");
             var inst = GetActiveGeneralInstance();
             if (inst == null)
             {
                 Debug.LogError("inst = null");
                 return;
             }
+            
+            Debug.Log($"questId : {inst.QuestId} ");
             if (_questUI != null) return;
             if (QuestUI == null) return;
             // questUI에서 UIController를 받아옵니다
@@ -790,6 +850,7 @@ namespace _05._CSJ_Folder.Scripts.Quest
             
             // TODO : 정식 출시 시 삭제
             _questUI.OnForceClear += ForceQuestComplete;
+            _questUI.OnForceInit += ForceQuestReset;
 
             if (_temporaryQuestController != null)
             {
@@ -801,6 +862,15 @@ namespace _05._CSJ_Folder.Scripts.Quest
 
             // 퀘스트 ui에 퀘스트 정보를 전달합니다
             OnQuestUpdated?.Invoke(so, inst);
+            
+            foreach (var kv in _temporaryInstances)
+            {
+                var tinst = kv.Value;
+                var def = tinst.Def;
+                var goal = def?.TempoGoal;
+                Debug.Log($"TEMP DEF {def?.name} id={tinst.QuestId} req={tinst.DemandedGoalCount} " +
+                          $"state={tinst.QuestState} cur={tinst.CurrentGoalCount}");
+            }
         }
 
         /// <summary>
@@ -814,6 +884,20 @@ namespace _05._CSJ_Folder.Scripts.Quest
             var inst = GetActiveGeneralInstance();
             if (inst == null) return;
             if (!_generalDefs.TryGetValue(inst.QuestId, out var def)) return;
+
+            // 퀘스트UI의 퀘스트 번호를 인스턴스의 퀘스트 번호로 초기화
+            _questUI.QuestNumber = inst.GeneralQuestCount;
+            // 퀘스트UI에 퀘스트 정보를 업데이트
+            _questUI.UpdateQuest(def, inst);
+        }
+        
+        /// <summary>
+        /// 퀘스트 ui를 새로고침 합니다
+        /// </summary>
+        private void RefreshActiveQuestUI(GeneralQuestDefinitionSO def, GeneralQuestInstance inst)
+        {
+            // questUI가 비할당된 경우 탈출
+            if (_questUI == null) return;
 
             // 퀘스트UI의 퀘스트 번호를 인스턴스의 퀘스트 번호로 초기화
             _questUI.QuestNumber = inst.GeneralQuestCount;
@@ -1092,6 +1176,7 @@ namespace _05._CSJ_Folder.Scripts.Quest
         private QuestData BuildQuestData()
         {
             var generalInst = GetActiveGeneralInstance();
+            if (generalInst == null) generalInst = _completedInstance;
 
             // 현재 진행 중인 퀘스트 내용을 바탕으로 GeneralQuestData을 제작합니다.
             var general = new GeneralQuestData
@@ -1117,11 +1202,17 @@ namespace _05._CSJ_Folder.Scripts.Quest
                 });
             }
 
+            var tutorial = new TutorialQuestData()
+            {
+                ClearedTutorialQuestIds = _clearedTutorialQuestIds
+            };
+
             // QuestData를 반환합니다.
             return new QuestData
             {
                 General = general,
                 Temporary = temporary,
+                Tutorial = tutorial,
             };
         }
 
@@ -1132,14 +1223,10 @@ namespace _05._CSJ_Folder.Scripts.Quest
         {
             // General QuestData가 존재한다면
             if (data.General != null)
-            {
-                Debug.Log($"General QuestData : {data.General.ActiveQuestId}, ClearQuest {data.General.ClearedQuestCount}, {data.General.CurrentQuestStage}, {data.General.CurrentClearedStage}");
+            { 
                 ClearedQuestCount = data.General.ClearedQuestCount;
                 CurrentQuestStage = data.General.CurrentQuestStage;
                 CurrentClearedStage = data.General.CurrentClearedStage;
-                
-                Debug.Log($"General QuestData : {data.General.ActiveQuestId}, ClearQuest {ClearedQuestCount}, {CurrentQuestStage}, {CurrentClearedStage}");
-
                 if (!string.IsNullOrEmpty(data.General.ActiveQuestId) &&
                     _generalDefs.TryGetValue(data.General.ActiveQuestId, out var def))
                 {
@@ -1172,6 +1259,11 @@ namespace _05._CSJ_Folder.Scripts.Quest
                     def.GoalCountAdjust(Mathf.Max(0, t.Value.Progress));
                 }
             }
+
+            if (data.Tutorial != null)
+            {
+                _clearedTutorialQuestIds = data.Tutorial.ClearedTutorialQuestIds;
+            }
         }
 
         private void RebuildGeneralQuest(QuestData data)
@@ -1191,11 +1283,11 @@ namespace _05._CSJ_Folder.Scripts.Quest
                     for (int i = 0; i < parity.Count; i++)
                     {
                         var quest = parity[i];
-                        if (!found && quest.questId == activeId) found = true;
                         if (found)
                         {
                             _generalQuests.Enqueue(quest);
                         }
+                        if (!found && quest.questId == activeId) found = true;
                     }
                 }
             }
@@ -1432,6 +1524,7 @@ namespace _05._CSJ_Folder.Scripts.Quest
         
         #endregion
         
+        #region editor-only
         // 클리어 버튼 / 정식 빌드에선 빠질 예정
         private void ForceQuestComplete()
         {
@@ -1441,6 +1534,78 @@ namespace _05._CSJ_Folder.Scripts.Quest
             MarkCompleted(GetActiveQuestDefinition(),inst);
         }
 
+        public void ForceQuestReset()
+        {
+            if (_isResetting) return;
+            _isResetting = true;
+
+            try
+            {
+                CurrentClearedStage = 0;
+                CurrentQuestStage = 1;
+                ClearedQuestCount = 0;
+
+                _activeGeneralId = null;
+
+                _tutorialQuests ??= new Queue<TutorialQuestDefinitionSO>();
+                _generalQuests ??= new Queue<GeneralQuestDefinitionSO>();
+                _oddSequence ??= new Queue<RoutineQuestDefinitionSO>();
+                _evenSequence ??= new Queue<RoutineQuestDefinitionSO>();
+
+                _instances ??= new Dictionary<string, QuestInstance>();
+                _generalInstances ??= new Dictionary<string, GeneralQuestInstance>();
+                _generalDefs ??= new Dictionary<string, GeneralQuestDefinitionSO>();
+                _clearedTutorialQuestIds ??= new List<string>();
+
+                _temporaryInstances ??= new Dictionary<string, TemporaryInstance>();
+                _temporaryQuests ??= new Queue<TemporaryInstance>();
+                _dailyQuests ??= new Queue<TemporaryInstance>();
+                _weeklyQuests ??= new Queue<TemporaryInstance>();
+
+                _tutorialQuests.Clear();
+                _generalQuests.Clear();
+                _oddSequence.Clear();
+                _evenSequence.Clear();
+
+                _instances.Clear();
+                _generalInstances.Clear();
+                _generalDefs.Clear();
+                _clearedTutorialQuestIds.Clear();
+
+                _temporaryInstances.Clear();
+                _temporaryQuests.Clear();
+                _dailyQuests.Clear();
+                _weeklyQuests.Clear();
+
+                BuildCatalog();
+
+                GeneralQuestEnqueue();
+                EnsureGeneralActive();
+
+                if (_temporaryQuestController != null)
+                {
+                    _temporaryQuestController.QuestInit(_temporaryQuest, _temporaryInstances);
+                }
+
+                foreach (var kv in _temporaryInstances)
+                {
+                    var t = kv.Value;
+                    if (t == null) continue;
+                    t.QuestState = QuestState_Enum.Active;
+                    t.GoalCountInit();
+                    OnTempoQuestUpdated?.Invoke(t);
+                }
+                
+                ActiveQuestUI();
+                RequestSave(0.1f);
+            }
+            finally
+            {
+                _isResetting = false;
+            }
+        }
+
+        #endregion
     }
 
     internal static class TaskHelper

--- a/Assets/05. CSJ_Folder/Scripts/Quest/SO/QuestDefinition/StageClearQuest.asset
+++ b/Assets/05. CSJ_Folder/Scripts/Quest/SO/QuestDefinition/StageClearQuest.asset
@@ -12,11 +12,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b1b625b98e1b311488b6021c77b14924, type: 3}
   m_Name: StageClearQuest
   m_EditorClassIdentifier: 
-  questName: 
+  questName: "\uC2A4\uD14C\uC774\uC9C0\uB97C \uD074\uB9AC\uC5B4\uD558\uC790 "
   Reward: {fileID: 0}
-  Goal: {fileID: 0}
-  questId: 
-  GeneralType: 0
-  RepeatType: 0
-  RequiredQuestClearMin: 0
+  Goal: {fileID: 11400000, guid: bd593c69a6b0d7246bc9f1e80198cc37, type: 2}
+  questId: 20005
+  GeneralType: 3
+  RepeatType: 1
+  RequiredQuestClearMin: 2
   Parity: 0

--- a/Assets/05. CSJ_Folder/Scripts/Quest/SO/QuestDefinition/Temporary/EquipmentEnchant.asset
+++ b/Assets/05. CSJ_Folder/Scripts/Quest/SO/QuestDefinition/Temporary/EquipmentEnchant.asset
@@ -12,11 +12,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0fe81e13c820472494352b5eee7bba82, type: 3}
   m_Name: EquipmentEnchant
   m_EditorClassIdentifier: 
-  questName: 
+  questName: "\uC7A5\uBE44\uB97C "
   Reward: {fileID: 0}
-  TempoQuestContent: 
-  DailyQuestId: 0
-  WeeklyQuestId: 0
-  dailyCountArray: 
-  weeklyCountArray: 
-  TempoGoal: {fileID: 0}
+  TempoQuestContent: "\uD68C \uAC15\uD654\uD558\uC790"
+  DailyQuestId: 100022
+  WeeklyQuestId: 200035
+  dailyCountArray: 030000000500000007000000
+  weeklyCountArray: 1e0000003c00000064000000
+  TempoGoal: {fileID: 11400000, guid: bbc2358d7940d7145a2ee411e5fc9c11, type: 2}

--- a/Assets/05. CSJ_Folder/Scripts/Quest/SO/QuestGoal/Temporary/EquipmentEnchant.asset
+++ b/Assets/05. CSJ_Folder/Scripts/Quest/SO/QuestGoal/Temporary/EquipmentEnchant.asset
@@ -12,12 +12,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 43cbdb604216493f973c3fb1fb878055, type: 3}
   m_Name: EquipmentEnchant
   m_EditorClassIdentifier: 
-  keyValue: 0
+  keyValue: 3
   enumKey:
-    kind: 0
+    kind: 2
     monster: 0
     money: 0
-    itemType: 0
+    itemType: 1
     upgrade: 0
     active: 0
     achieveText: 

--- a/Assets/05. CSJ_Folder/Scripts/Quest/SO/Routine Sequence.asset
+++ b/Assets/05. CSJ_Folder/Scripts/Quest/SO/Routine Sequence.asset
@@ -16,6 +16,8 @@ MonoBehaviour:
   - {fileID: 11400000, guid: daecfa54877339c48aca07ef5d84600b, type: 2}
   - {fileID: 11400000, guid: 8afea45dd936b5d428fdf5aead681e01, type: 2}
   - {fileID: 11400000, guid: 18af85ba99903e946b93cce567db756f, type: 2}
+  - {fileID: 11400000, guid: 688a7902e816669449fb054357651407, type: 2}
+  - {fileID: 11400000, guid: d827d0a34a1cbc2478525df1b98ee0e5, type: 2}
   - {fileID: 11400000, guid: 7961651638c7cb44f88390fdf486597a, type: 2}
   - {fileID: 11400000, guid: 6828367ea38b82f4c8fc633d56f16e8f, type: 2}
   - {fileID: 11400000, guid: 5d5c9d4ef1bdee14dbac77665664e2c6, type: 2}
@@ -24,6 +26,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: daecfa54877339c48aca07ef5d84600b, type: 2}
   - {fileID: 11400000, guid: 8afea45dd936b5d428fdf5aead681e01, type: 2}
   - {fileID: 11400000, guid: 18af85ba99903e946b93cce567db756f, type: 2}
+  - {fileID: 11400000, guid: 688a7902e816669449fb054357651407, type: 2}
   - {fileID: 11400000, guid: bfe82231a4046b744aec9ab424cc445b, type: 2}
   - {fileID: 11400000, guid: f0742ec02711ca24daea18680fbb6fa8, type: 2}
   - {fileID: 11400000, guid: 5d5c9d4ef1bdee14dbac77665664e2c6, type: 2}

--- a/Assets/05. CSJ_Folder/Scripts/Quest/SO/Temporary Sequence.asset
+++ b/Assets/05. CSJ_Folder/Scripts/Quest/SO/Temporary Sequence.asset
@@ -18,3 +18,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 53a11ab15c65dfb4bb315608ab81ee1c, type: 2}
   - {fileID: 11400000, guid: 4206e93ecf772124fa4cf8a825224b35, type: 2}
   - {fileID: 11400000, guid: df30375dbbde52046a244e8ea0d9c3f1, type: 2}
+  - {fileID: 11400000, guid: 66b5e0b147c06da4d810dc9c11833379, type: 2}

--- a/Assets/05. CSJ_Folder/Scripts/Quest/TemporaryInstance.cs
+++ b/Assets/05. CSJ_Folder/Scripts/Quest/TemporaryInstance.cs
@@ -40,6 +40,11 @@ namespace _05._CSJ_Folder.Scripts.Quest
             return true;
         }
 
+        public override bool IsOnce()
+        {
+            return false;
+        }
+
 
     }
 }

--- a/Assets/05. CSJ_Folder/Scripts/Quest/UI/QuestUIController.cs
+++ b/Assets/05. CSJ_Folder/Scripts/Quest/UI/QuestUIController.cs
@@ -16,12 +16,13 @@ public class QuestUIController : MonoBehaviour
     [SerializeField] private TextMeshProUGUI _questGoalCountText;    
     [SerializeField] private Button _CheatButton;
     [SerializeField] private Image _questCurrentGoalImage;
+    [SerializeField] private Button _InitButton;
 
     
-    public int QuestNumber;
-    [SerializeField] public GeneralQuestInstance QuestInst;
-    [SerializeField] public GeneralQuestDefinitionSO QuestDef;
-    public int QuestGoalCount;
+    [NonSerialized] public int QuestNumber;
+    public GeneralQuestInstance QuestInst;
+    [NonSerialized] public GeneralQuestDefinitionSO QuestDef;
+    private int QuestGoalCount;
     
     private GoalDefinitionSO QuestGoal;
     private QuestRewardSO QuestReward;
@@ -78,23 +79,21 @@ public class QuestUIController : MonoBehaviour
             {
                 _questGoalCountText.text = $"{QuestGoalCount} / {QuestGoal.RequireCount}";
                 _questButton.image.canvasRenderer.SetAlpha(0.3f);
-                ColorBlock buttonColor = _questButton.colors;
-                buttonColor.normalColor = Color.black;
             }
             else
             {
                 _questGoalCountText.text = "클리어";
-                _questButton.image.canvasRenderer.SetAlpha(0.7f);
-                ColorBlock buttonColor = _questButton.colors;
-                buttonColor.normalColor = Color.white;
             }
         }
+        _questButton.image.canvasRenderer.SetAlpha(
+            QuestInst.QuestState == QuestState_Enum.Completed ? 0.7f : 0.3f);
 
         //_questCurrentGoalImage.sprite = QuestReward.Reward.RewardIcon;
     }
     
     
     public Action OnForceClear;
+    public Action OnForceInit;
     [SerializeField] private Button KillButton;
     [SerializeField] private Button GachaButton;
     [SerializeField] private Button LevelUpButton;
@@ -102,6 +101,11 @@ public class QuestUIController : MonoBehaviour
     private void OnClickCheatButton()
     {
         OnForceClear?.Invoke();
+    }
+
+    private void OnClickInitButton()
+    {
+        OnForceInit?.Invoke();
     }
     
     private void SubmitButton()
@@ -116,6 +120,8 @@ public class QuestUIController : MonoBehaviour
             LevelUpButton.onClick.AddListener(OnClickLevelUpButton);
         if (UpgradeButton !=null)
             UpgradeButton.onClick.AddListener(OnClickUpgradeButton);
+        if (_InitButton is not null)
+            _InitButton.onClick.AddListener(OnClickInitButton);
     }
 
     private void OnClickKillButton()
@@ -143,4 +149,5 @@ public class QuestUIController : MonoBehaviour
         QuestSignalManager.Instance.Upgrade(UpgradeType.Def,5);
         QuestSignalManager.Instance.Upgrade(UpgradeType.Hp, 5);
     }
+    
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
여러 버그들을 수정하였습니다
그리고 퀘스트 초기화 버튼을 추가하였습니다


## 📎 상세 작업 내용

- 퀘스트 계산이 -1로 되어있음 (1단계 이전꺼가 표시)
-> 해당 부분 수정 
데이터 불러오기시에 기존 퀘스트 데이터를 불러와 활성화 전환 후 다시 퀘스트 목록을 돌면서 큐에 삽입을 진행하여
기존에 퀘스트가 2번 삽입되고 있었습니다.

- 퀘스트 초기화 기능 추가
-> 버튼을 통해서 구현 

- 현재 튜토리얼 퀘스트가 재삽입되는 문제
-> 해당 부분 수정
현재 데이터를 로드할 때 마지막 수행중이던 퀘스트가 튜토리얼 퀘스트라면 큐에서 제거하고 마지막 수행중이던 튜토리얼 퀘스트를 삽입하는데 만일 루틴 퀘스트 였다면 튜토리얼에 대한 정보 저장이 없어서 이부분이 생략되어 튜토리얼이 다시 처음부터 삽입
따라서 저장 데이터에 튜토리얼 퀘스트 정보도 포함 

- 스테이지 클리어 미션이 미리 해당 스테이지가 클리어되어 있어도 진행되지 않는 현상
-> 스테이지 클리어 미션 삽입시에 해당 부분 완료 여부를 살피고 삽입

- 퀘스트 완료 상태인 상태로 게임을 종료하면 저장이 제대로 안되고 다음에 퀘스트를 처음부터 시작하는 현상
-> 저장시에 현재 진행중인 퀘스트만을 대상으로 저장하여 완료 상태인 퀘스트가 저장되지 않았음
이 부분 저장 데이터 구조 수정


## 미 해결된 사항
- 퀘스트 로드시에 한 바퀴 퀘스트 순회를 마치면 퀘스트 큐가 비어서 멈추는 현상
- 가끔씩 저장 불러오기시 퀘스트가 앞뒤로 1칸 정도 차이나는 현상 (이부분은 강제 종료시 저장 시에 캐시 데이터를 저장하는데 이부분에서 아직 갱신이 안되어 이전 버전으로 표시되는게 아닌가 싶습니다)
- 퀘스트 보상 미구현 - (현재 보상있는 퀘스트는 전부 50골드로 통일되어있음, 이부분은 아직 재화 기획이 덜들어와서 미삽입)
- 퀘스트와 기능 미연결 (- 대부분의 퀘스트의 내용들이 아직 연결되어 있지 않음 - 이부분은 기업 제출전까지 연결될 예정 아마 이번 빌드에선 못 올라갈 것 같습니다)
