### PR TITLE
[Fix] Tilemap Scale Fix and SpawnPoint fix

### DIFF
--- a/Assets/06. KYH_Folder/Prefabs/BattleField_0.prefab
+++ b/Assets/06. KYH_Folder/Prefabs/BattleField_0.prefab
@@ -285,6 +285,14 @@ PrefabInstance:
     m_TransformParent: {fileID: 5867331170467977554}
     m_Modifications:
     - target: {fileID: 1566965588936742191, guid: 1e373edee31976e4188d57dd2c730b1c, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1566965588936742191, guid: 1e373edee31976e4188d57dd2c730b1c, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1566965588936742191, guid: 1e373edee31976e4188d57dd2c730b1c, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -327,6 +335,18 @@ PrefabInstance:
     - target: {fileID: 7559283812842721845, guid: 1e373edee31976e4188d57dd2c730b1c, type: 3}
       propertyPath: m_Name
       value: Sample Grid
+      objectReference: {fileID: 0}
+    - target: {fileID: 8079882306368814701, guid: 1e373edee31976e4188d57dd2c730b1c, type: 3}
+      propertyPath: m_CellGap.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8079882306368814701, guid: 1e373edee31976e4188d57dd2c730b1c, type: 3}
+      propertyPath: m_CellSize.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8079882306368814701, guid: 1e373edee31976e4188d57dd2c730b1c, type: 3}
+      propertyPath: m_CellSize.y
+      value: 0.5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:

--- a/Assets/08. LSW_Folder/Scenes/Game.unity
+++ b/Assets/08. LSW_Folder/Scenes/Game.unity
@@ -1077,6 +1077,30 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1901312791}
     m_Modifications:
+    - target: {fileID: 782893621085879409, guid: 32a42e3c827328d43bea0cbf4fb4e7ae, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.08
+      objectReference: {fileID: 0}
+    - target: {fileID: 782893621085879409, guid: 32a42e3c827328d43bea0cbf4fb4e7ae, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 1364889419357502999, guid: 32a42e3c827328d43bea0cbf4fb4e7ae, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.77
+      objectReference: {fileID: 0}
+    - target: {fileID: 1364889419357502999, guid: 32a42e3c827328d43bea0cbf4fb4e7ae, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3.16
+      objectReference: {fileID: 0}
+    - target: {fileID: 1801662737690472531, guid: 32a42e3c827328d43bea0cbf4fb4e7ae, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 8.89
+      objectReference: {fileID: 0}
+    - target: {fileID: 1801662737690472531, guid: 32a42e3c827328d43bea0cbf4fb4e7ae, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.51
+      objectReference: {fileID: 0}
     - target: {fileID: 4961262806984856264, guid: 32a42e3c827328d43bea0cbf4fb4e7ae, type: 3}
       propertyPath: m_CellSize.y
       value: 0.5
@@ -1132,6 +1156,22 @@ PrefabInstance:
     - target: {fileID: 7127953379043338169, guid: 32a42e3c827328d43bea0cbf4fb4e7ae, type: 3}
       propertyPath: m_IsActive
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7417218957810488596, guid: 32a42e3c827328d43bea0cbf4fb4e7ae, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.79
+      objectReference: {fileID: 0}
+    - target: {fileID: 7417218957810488596, guid: 32a42e3c827328d43bea0cbf4fb4e7ae, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.49
+      objectReference: {fileID: 0}
+    - target: {fileID: 8751348559560387751, guid: 32a42e3c827328d43bea0cbf4fb4e7ae, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.89
+      objectReference: {fileID: 0}
+    - target: {fileID: 8751348559560387751, guid: 32a42e3c827328d43bea0cbf4fb4e7ae, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.44
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -21057,11 +21097,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 391546710642121371, guid: 7c8fcd8d617343f4aa048d4b51542918, type: 3}
       propertyPath: attackRange
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 391546710642121371, guid: 7c8fcd8d617343f4aa048d4b51542918, type: 3}
       propertyPath: attackRange2
-      value: 3
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 391546710642121371, guid: 7c8fcd8d617343f4aa048d4b51542918, type: 3}
       propertyPath: _dontDestroyOnLoad


### PR DESCRIPTION
임시 타일맵 확장하여 알고리즘의 사용 확장, 몬스터 임시 리스폰 포인트 조절하여 이동하지않는경우 오차범위 최소화

## 📄 작업 내용 요약

타일맵 확장공사

적 리스폰포인트 수정

* 참고

a스타알고리즘을 이용하여 움직일때에 이동후 공격으로 전환될때 오차범위때문에 멈추는 현상있음.

FSM내부 수정혹은 알고리즘에서의 수정이 필요함.
