### PR TITLE
[Fix] 편성창에서 캐릭터 겹치는 문제 수정

### DIFF
--- a/Assets/09. PSH_Folder/Prefabs/Big/FormationRenderingCamera.prefab
+++ b/Assets/09. PSH_Folder/Prefabs/Big/FormationRenderingCamera.prefab
@@ -27,7 +27,7 @@ Transform:
   m_GameObject: {fileID: 346598121072445655}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -485, y: 1685, z: -11.7}
+  m_LocalPosition: {x: -330, y: 1685, z: -11.7}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -155,7 +155,7 @@ Transform:
   m_GameObject: {fileID: 2364900405646481031}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -485, y: 1685, z: -11.7}
+  m_LocalPosition: {x: -400, y: 1685, z: -11.7}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -283,7 +283,7 @@ Transform:
   m_GameObject: {fileID: 4752165575493637423}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -485, y: 1685, z: -11.7}
+  m_LocalPosition: {x: -360, y: 1685, z: -11.7}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -411,7 +411,7 @@ Transform:
   m_GameObject: {fileID: 5955565580478462935}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -485, y: 1685, z: -11.7}
+  m_LocalPosition: {x: -370, y: 1685, z: -11.7}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -539,7 +539,7 @@ Transform:
   m_GameObject: {fileID: 6707828236752540987}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -485, y: 1685, z: -11.7}
+  m_LocalPosition: {x: -390, y: 1685, z: -11.7}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -667,7 +667,7 @@ Transform:
   m_GameObject: {fileID: 7425669517064748436}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -485, y: 1685, z: -11.7}
+  m_LocalPosition: {x: -340, y: 1685, z: -11.7}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -795,7 +795,7 @@ Transform:
   m_GameObject: {fileID: 7562211989902137291}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -485, y: 1685, z: -11.7}
+  m_LocalPosition: {x: -350, y: 1685, z: -11.7}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -966,7 +966,7 @@ Transform:
   m_GameObject: {fileID: 8527560582267673331}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -485, y: 1685, z: -11.7}
+  m_LocalPosition: {x: -380, y: 1685, z: -11.7}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []


### PR DESCRIPTION
렌더카메라 분명히 퍼트려놨는데 왜 다시 모였을까

## 📄 작업 내용 요약


## 📎 상세 작업 내용
